### PR TITLE
fix: enable CORS for graphql

### DIFF
--- a/packages/auto-nlp-core/src/app.module.ts
+++ b/packages/auto-nlp-core/src/app.module.ts
@@ -44,6 +44,7 @@ import { ApolloDriver, ApolloDriverConfig } from '@nestjs/apollo';
     HttpModule,
     GraphQLModule.forRoot<ApolloDriverConfig>({
       driver: ApolloDriver,
+      cors: true,
       autoSchemaFile: path.join(process.cwd(), 'src/schema.gql'),
       installSubscriptionHandlers: true,
     })


### PR DESCRIPTION
- temporary fix to use backend for development